### PR TITLE
[issue-53] Add sign in support with firebase auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.0",
+    "firebase": "^8.3.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -10,34 +10,35 @@ import { Login } from './stories/pages/Login/Login';
 import { Home } from './stories/pages/Home/Home';
 import { Signup } from './stories/pages/Signup/Signup';
 import { Search } from './stories/pages/Search/Search';
+import { AuthProvider } from './Auth';
 
 function App() {
   return (
-    <Router>
-      <Header rightContent={<MainMenu />} />
-      <Main>
-        <Switch>
-          <Route exact path="/login">
-            <Login />
-          </Route>
-          <Route exact path="/signup">
-            <Signup />
-          </Route>
-          <Route exact path={[
-            '/search',
-            '/search/:searchTerms']}>
-            <Search />
-          </Route>
-          <Route exact path="/recipes/:recipeId">
-            <Recipe />
-          </Route>
-          <Route path="/">
-            <Home />
-          </Route>
-        </Switch>
-      </Main>
-      <Footer />
-    </Router>
+    <AuthProvider>
+      <Router>
+        <Header rightContent={<MainMenu />} />
+        <Main>
+          <Switch>
+            <Route exact path="/login">
+              <Login />
+            </Route>
+            <Route exact path="/signup">
+              <Signup />
+            </Route>
+            <Route exact path={['/search', '/search/:searchTerms']}>
+              <Search />
+            </Route>
+            <Route exact path="/recipes/:recipeId">
+              <Recipe />
+            </Route>
+            <Route path="/">
+              <Home />
+            </Route>
+          </Switch>
+        </Main>
+        <Footer />
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import fire from './fire';
+
+/**
+ * A context to be used by components in the tree, holds
+ * the logged in user.
+ */
+export const AuthContext = React.createContext();
+
+/**
+ * A class for an AuthProvider, handles getting user login
+ * using firebase authentication.
+ *
+ * @param {node} children
+ * @return {object} (
+ *  <AuthProvider>
+ *    {children}
+ *  </AuthProvider>
+ * )
+ */
+export const AuthProvider = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState(null);
+
+  useEffect(() => {
+    fire.auth().onAuthStateChanged(setCurrentUser);
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        currentUser,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+AuthProvider.propTypes = {
+  /**
+   * AuthProvider's children
+   */
+  children: PropTypes.node,
+};

--- a/src/fire.js
+++ b/src/fire.js
@@ -1,0 +1,23 @@
+import firebase from 'firebase';
+
+// Made with guidance from :
+// https://www.youtube.com/watch?v=cFgoSrOui2M
+
+/**
+ * A config method to handle all the credentials to connect
+ * to our firebase project.
+ */
+const firebaseConfig = {
+  apiKey: 'AIzaSyCaVXsW8SaK3pNPZ4Igaf2o7ZatdwCBlp4',
+  authDomain: 'cooks-books-app.firebaseapp.com',
+  databaseURL: 'https://cooks-books-app-default-rtdb.firebaseio.com',
+  projectId: 'cooks-books-app',
+  storageBucket: 'cooks-books-app.appspot.com',
+  messagingSenderId: '5777053309',
+  appId: '1:5777053309:web:b5c9aa32a44773fca38314',
+  measurementId: 'G-JJN7SC1CT2',
+};
+
+// Initialize Firebase
+const fire = firebase.initializeApp(firebaseConfig);
+export default fire;

--- a/src/stories/components/MainMenu/MainMenu.js
+++ b/src/stories/components/MainMenu/MainMenu.js
@@ -1,8 +1,10 @@
 import './styles.scss';
 
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button } from '../Button/Button';
 import { Link } from 'react-router-dom';
+import { AuthContext } from '../../../Auth';
+
 
 /**
  * Component for Main Menu element.
@@ -14,6 +16,8 @@ import { Link } from 'react-router-dom';
  * )
  */
 export const MainMenu = () => {
+  const { currentUser } = useContext(AuthContext);
+
   return (
     <ul className="main-menu">
       <li className="main-menu__item">
@@ -21,7 +25,16 @@ export const MainMenu = () => {
           className="main-menu__link main-menu__link--search">Search</Link>
       </li>
       <li className="main-menu__item">
-        <Button url="/login" text="Login" />
+        {
+          currentUser === null &&
+          <Button url="/login" text="Login" />
+        }
+        {
+          currentUser !== null &&
+          // TODO: Make this redirect to account once we have that
+          //   for now it goes to login, where I've added a temp 'logout' button
+          <Button url="/login" text={currentUser.email} />
+        }
       </li>
     </ul>
   );

--- a/src/stories/pages/Home/Home.js
+++ b/src/stories/pages/Home/Home.js
@@ -14,6 +14,7 @@ import ArtChicken from '../../../images/artwork-chicken.svg';
 import ArtDessert from '../../../images/artwork-dessert.svg';
 import { SplitSection } from '../../layouts/SplitSection/SplitSection';
 
+
 /**
  * Component for Home page.
  *

--- a/src/stories/pages/Login/Login.js
+++ b/src/stories/pages/Login/Login.js
@@ -1,6 +1,7 @@
 import '../../../scss/utility.scss';
 
-import React from 'react';
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { Constrain } from '../../layouts/Constrain/Constrain';
 import { Grid } from '../../layouts/Grid/Grid';
@@ -8,6 +9,8 @@ import { Link } from 'react-router-dom';
 import Artwork from '../../../images/artwork-4.svg';
 import { Form } from '../../components/Form/Form';
 import { FormItem } from '../../components/FormItem/FormItem';
+import fire from '../../../fire';
+import { Button } from '../../components/Button/Button';
 
 /**
  * Component for Login page.
@@ -19,6 +22,43 @@ import { FormItem } from '../../components/FormItem/FormItem';
  */
 
 export const Login = () => {
+  const [email, setEmail] = useState(null);
+  const [password, setPassword] = useState(null);
+  const history = useHistory();
+
+  /**
+   * Logs in with the current values from email and password,
+   *   navigates to home if succesful login.
+   */
+  const handleLogin = () => {
+    fire
+      .auth()
+      .signInWithEmailAndPassword(email, password)
+      .catch((err) => {
+        switch (err.code) {
+        case 'auth/invalid-email':
+        case 'auth/user-disabled':
+        case 'auth/user-not-found':
+          // TODO: Visually alert user of error
+          // alert(err.message);
+          break;
+        }
+      });
+    // TODO: Visually alert user of login
+    // alert('logging in as user: ' + email);
+    history.push(`/`);
+  };
+
+  /**
+   * Logs the user out of the current firebase auth, navigates to home.
+   */
+  const handleLogout = () => {
+    fire.auth().signOut();
+    // TODO: Visually alert user of signout
+    // alert('logging out as user: ' + email);
+    history.push(`/`);
+  };
+
   return (
     <div className="login">
       <Constrain>
@@ -33,11 +73,35 @@ export const Login = () => {
               Sign up here</Link>.</p>
           </div>
           <div className="grid__item">
-            <Form buttonColor="blue" modifierClasses="form--login"
-              buttonText="Login">
-              <FormItem type="text" placeholder="Username" />
-              <FormItem type="password" placeholder="Password" />
+            <Form
+              buttonColor="blue"
+              modifierClasses="form--login"
+              buttonText="Login"
+              handleClick={(e) => {
+                e.preventDefault();
+                handleLogin();
+              }}
+            >
+              <FormItem
+                type="text"
+                placeholder="Email"
+                handleChange={(e) => setEmail(e.target.value)}
+                value={email}
+              />
+              <FormItem
+                type="password"
+                placeholder="Password"
+                handleChange={(e) => setPassword(e.target.value)}
+                value={password}
+              />
             </Form>
+            <Button
+              text='logout'
+              isButton={true}
+              onClick={(e) => {
+                e.preventDefault();
+                handleLogout();
+              }}></Button>
           </div>
         </Grid>
       </Constrain>

--- a/src/stories/pages/Signup/Signup.js
+++ b/src/stories/pages/Signup/Signup.js
@@ -1,6 +1,7 @@
 import '../../../scss/utility.scss';
 
-import React from 'react';
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { Constrain } from '../../layouts/Constrain/Constrain';
 import { Grid } from '../../layouts/Grid/Grid';
@@ -8,6 +9,7 @@ import { Link } from 'react-router-dom';
 import Artwork from '../../../images/artwork-3.svg';
 import { Form } from '../../components/Form/Form';
 import { FormItem } from '../../components/FormItem/FormItem';
+import fire from '../../../fire';
 
 /**
  * Component for Signup page.
@@ -19,29 +21,91 @@ import { FormItem } from '../../components/FormItem/FormItem';
  */
 
 export const Signup = () => {
+  const [email, setEmail] = useState(null);
+  const [password, setPassword] = useState(null);
+  const history = useHistory();
+
+  /**
+   * Signs in with the currently input username and password,
+   *   navigates to home on successful login.
+   *
+   * @throws errors if email si already in use,
+   *   or if the email is incorrectly formatted.
+   */
+  const handleSignup = () => {
+    fire
+      .auth()
+      .createUserWithEmailAndPassword(email, password)
+      .catch((err) => {
+        switch (err.code) {
+        case 'auth/email-already-in-use':
+        case 'auth/invalid-email':
+          // TODO: Visually alert user of error
+          // alert(err.message);
+          break;
+        }
+      });
+    // TODO: Visually alert user of account creation
+    // alert('creating user: ' + email);
+    history.push(`/`);
+  };
+
+  // TODO: remove this later if not needed
+  // const authListener = () => {
+  //   fire.auth().onAuthStateChanged((user) => {
+  //     if (user) {
+  //       setUser(user);
+  //     } else {
+  //       setUser('');
+  //     }
+  //   });
+  // };
+
   return (
     <div className="signup">
       <Constrain>
         <Grid numColumns={2} modifierClasses="grid--special">
           <div className="grid__item">
-            <img src={Artwork}
-              alt="Decorative Graphics" />
-            <h1>Hello, <span className="text-normal">there</span>.</h1>
-            <p>Signup into your account to add new recipes,
-              create meal plans and much more.</p>
-            <p>Don’t have an account yet? <Link to="login">
-              Login here</Link>.</p>
+            <img src={Artwork} alt="Decorative Graphics" />
+            <h1>
+              Hello, <span className="text-normal">there</span>.
+            </h1>
+            <p>
+              Signup into your account to add new recipes, create meal plans and
+              much more.
+            </p>
+            <p>
+              Don’t have an account yet? <Link to="login">Login here</Link>.
+            </p>
           </div>
           <div className="grid__item">
-            <Form buttonColor="red" modifierClasses="form--login"
-              buttonText="Create account">
+            <Form
+              buttonColor="red"
+              modifierClasses="form--login"
+              buttonText="Create account"
+              handleClick={(e) => {
+                e.preventDefault();
+                handleSignup();
+              }}
+            >
               <FormItem type="text" placeholder="Full Name" />
-              <FormItem type="emaill" placeholder="Email" />
+              <FormItem
+                type="email"
+                placeholder="Email"
+                handleChange={(e) => setEmail(e.target.value)}
+                value={email}
+              />
               <FormItem type="text" placeholder="Username" />
-              <FormItem type="password" placeholder="Password" />
-              <FormItem type="select" options={[
-                'Who you are', 'Chef', 'Foodie',
-              ]} />
+              <FormItem
+                type="password"
+                placeholder="Password"
+                handleChange={(e) => setPassword(e.target.value)}
+                value={password}
+              />
+              <FormItem
+                type="select"
+                options={['Who you are', 'Chef', 'Foodie']}
+              />
             </Form>
           </div>
         </Grid>


### PR DESCRIPTION
Add user sign in and register with google firebase authentication.

Sign up page allows registration of users (only using email and password right now, need to look into adding more fields to email registration). 

Sign out button added to login page, and header "login" changes to the email of the currently signed in user. This should definitely change to 'Account' later, but until we have a page for user info or better place to show who's logged in, I figure this shows functionality and shows us visually the user that is signed in.